### PR TITLE
docs: make file writer synchronous

### DIFF
--- a/automation/docs.js
+++ b/automation/docs.js
@@ -56,7 +56,7 @@ const buildDocs = report => {
       });
     })
     .then(result => {
-      fs.writeFile(OUTFILE, result);
+      fs.writeFileSync(OUTFILE, result);
     });
 };
 


### PR DESCRIPTION
Otherwise on node 11, at least, run into this error with the original
async version:

```
(node:4198) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at maybeCallback (fs.js:134:9)
    at Object.writeFile (fs.js:1180:14)
    at jsdoc2md.getTemplateData.then.then.result (/home/greg/resin/resin-semver/automation/docs.js:59:10)
```

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>