### PR TITLE
Drop lodash.memoize in favor of deep imports & limit @types/lodash to 4.14.121

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,21 +26,19 @@
   "author": "Lucian Buzzo <lucian@resin.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/lodash.memoize": "^4.1.2",
+    "@types/lodash": "^4.1.2",
     "@types/semver": "^5.4.0",
-    "lodash.memoize": "^4.1.2",
+    "lodash": "^4.1.2",
     "semver": "^5.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
-    "@types/lodash.sortby": "^4.7.4",
     "@types/mocha": "^2.2.41",
     "catch-uncommitted": "^1.0.0",
     "chai": "^4.1.0",
     "husky": "^0.14.3",
     "jsdoc-to-markdown": "^3.0.0",
     "lint-staged": "^4.0.4",
-    "lodash.sortby": "^4.7.0",
     "mocha": "^3.4.2",
     "prettier": "^1.6.1",
     "ts-node": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Lucian Buzzo <lucian@resin.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/lodash": "^4.1.2",
+    "@types/lodash": "^4.1.2 <=4.14.121",
     "@types/semver": "^5.4.0",
     "lodash": "^4.1.2",
     "semver": "^5.3.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var memoize = require("lodash.memoize");
+var memoize = require("lodash/memoize");
 var semver = require("semver");
 var trimOsText = function (version) {
     // Remove "Resin OS" and "Balena OS" text

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import memoize = require('lodash.memoize');
+import memoize = require('lodash/memoize');
 import * as semver from 'semver';
 
 type VersionInput = string | null | undefined;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sortBy = require('lodash.sortby');
+import sortBy = require('lodash/sortBy');
 import * as semver from '../src';
 import { versions } from './versions';
 

--- a/tslint.json
+++ b/tslint.json
@@ -23,6 +23,7 @@
     "no-empty-interface": false,
     "no-string-literal": false,
     "object-literal-key-quotes": [true, "as-needed"],
+    "import-blacklist": [true, "lodash"],
     "interface-name": [false],
     "interface-over-type-literal": false,
     "variable-name": [


### PR DESCRIPTION
> `@types/lodash@4.14.122` (dependency of @types/lodash.memoize@4.1.6) which got released yesterday break when used in TS < 2.8.
The current package.json states `"typescript": "^2.4.2"` and consumer projects can break with the new typings. (This broke the SDKs test cases on master and bumping the TS version is a major version change since it will cause issues to other modules.)
> 
> Independent lodash submodules are outdated and their typings use a `*` dependency for the `@types/lodash` package which cause the above issue.
We should consider dropping `lodash.memoize` in favor of tree shakable deep imports of `lodash` methods.
Moreover this will allow consumer projects (like the SDK) to avoid including both a treeshaked `lodash` & `lodash.memoize` independently and end up with smaller bundle size.

Resolves: #71
Resolves: #72
See: https://github.com/balena-io/balena-sdk/issues/642
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>